### PR TITLE
change useEffect or useFocusEffect to do screen refresh

### DIFF
--- a/screens/SavedScreen.js
+++ b/screens/SavedScreen.js
@@ -1,9 +1,8 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState, useCallback} from 'react';
 import {
   StyleSheet,
   useColorScheme,
   FlatList,
-  TouchableOpacity,
   SafeAreaView,
 } from 'react-native';
 import {
@@ -16,8 +15,8 @@ import {
   NativeBaseProvider,
 } from 'native-base';
 
-import {useAuth} from '../providers/AuthProvider';
 import {getAsyncSavedLocations} from '../data/asyncSavedLocations';
+import {useFocusEffect} from '@react-navigation/core';
 
 function SavedScreen({navigation}) {
   const isDarkMode = useColorScheme() === 'dark';
@@ -26,18 +25,24 @@ function SavedScreen({navigation}) {
   const [refresh, setRefresh] = useState(false);
 
   // load Saved Locations from AsyncStorage
-  useEffect(() => {
-    async function fetchData() {
-      try {
-        const res = await getAsyncSavedLocations();
-        setDATA(res);
-        return res;
-      } catch (error) {
-        throw error;
+  useFocusEffect(
+    useCallback(() => {
+      async function fetchData() {
+        try {
+          const res = await getAsyncSavedLocations();
+          setDATA(res);
+          return res;
+        } catch (error) {
+          throw error;
+        }
       }
-    }
-    fetchData();
-  }, [refresh]);
+      fetchData();
+      // this function runs on "screen unfocus/unmount"
+      return () => {
+        console.log('hello world');
+      };
+    }, []),
+  );
 
   //List Item Component
   const Item = ({name, fullItem}) => (


### PR DESCRIPTION
After sharing the `page not refreshing` issue with @beaunus, we found a long term solution using `useFocusEffect` from `react-navigate` instead of `useEffect`

https://reactnavigation.org/docs/function-after-focusing-screen/

We can implement this while we are updating our features, just indicate it on the changes or commits.

Thanks!